### PR TITLE
add limit param to bodyParser.urlencoded

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -77,16 +77,11 @@ export interface ParsedAsText {
     body: string;
 }
 
-export interface UrlencodedParserOptions {
+export interface UrlencodedParserOptions extends ParserOptions {
     /**
      * parse extended syntax with the qs module.
      */
     extended?: boolean;
-
-    /**
-     * maximum request body size. (default: '100kb')
-     */
-    limit?: number | string;
 
     /**
      * controls the maximum number of parameters that are allowed in the URL-encoded data.

--- a/index.d.ts
+++ b/index.d.ts
@@ -84,6 +84,11 @@ export interface UrlencodedParserOptions {
     extended?: boolean;
 
     /**
+     * maximum request body size. (default: '100kb')
+     */
+    limit?: number | string;
+
+    /**
      * controls the maximum number of parameters that are allowed in the URL-encoded data.
      * If a request contains more parameters than this value, a 413 will be returned to the client. Defaults to 1000.
      */


### PR DESCRIPTION
According to the docs, there should be a limit param here

https://github.com/expressjs/body-parser#limit-3