### PR TITLE
Update tslint version to latest (4.2.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "Felix Becker <felix.b@outlook.com>",
   "license": "ISC",
   "devDependencies": {
-    "tslint": "^3.13.0",
+    "tslint": "^4.2.0",
     "typescript": "^2.0.6",
     "typings": "^2.0.0"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "noUnusedParameters": true,
+    "noUnusedLocals": true
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -36,10 +36,7 @@
     "one-variable-per-declaration": [true, "ignore-for-loop"],
     "curly": true,
     "no-empty": true,
-    "no-duplicate-key": true,
-    "no-unreachable": true,
     "no-unused-expression": true,
-    "no-unused-variable": [true],
     "eofline": true,
     "trailing-comma": [true, {"singleline": "never", "multiline": "never"}],
     "align": [true, "parameters", "statements"]


### PR DESCRIPTION
**Changes**

- `tslint` updated to latest (4.2.0)
- Certain `tslint` rules have been deprecated; these same rules are now checked by `tsc` instead

Tested locally by running:
```
npm run lint
npm run build
npm test
```